### PR TITLE
Fetch missions - Fetch data

### DIFF
--- a/src/redux/missions/actions.js
+++ b/src/redux/missions/actions.js
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+export const FETCH_MISSIONS_REQUEST = 'FETCH_MISSIONS_REQUEST';
+export const FETCH_MISSIONS_SUCCESS = 'FETCH_MISSIONS_SUCCESS';
+export const FETCH_MISSIONS_FAILURE = 'FETCH_MISSIONS_FAILURE';
+
+export const fetchMissions = () => async (dispatch) => {
+  try {
+    dispatch({ type: FETCH_MISSIONS_REQUEST });
+
+    const response = await axios.get('https://api.spacexdata.com/v3/missions');
+
+    const selectedData = response.data.map((mission) => ({
+      mission_id: mission.mission_id,
+      mission_name: mission.mission_name,
+      description: mission.description,
+    }));
+
+    dispatch({
+      type: FETCH_MISSIONS_SUCCESS,
+      payload: selectedData,
+    });
+  } catch (error) {
+    dispatch({ type: FETCH_MISSIONS_FAILURE, payload: error.message });
+  }
+};

--- a/src/redux/missions/index.js
+++ b/src/redux/missions/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from 'redux';
+import missionsReducer from './reducers';
+
+const rootReducer = combineReducers({
+  missions: missionsReducer,
+});
+
+export default rootReducer;

--- a/src/redux/missions/reducers.js
+++ b/src/redux/missions/reducers.js
@@ -1,0 +1,26 @@
+import {
+  FETCH_MISSIONS_REQUEST,
+  FETCH_MISSIONS_SUCCESS,
+  FETCH_MISSIONS_FAILURE,
+} from './actions';
+
+const initialState = {
+  data: [],
+  loading: false,
+  error: null,
+};
+
+const missionsReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case FETCH_MISSIONS_REQUEST:
+      return { ...state, loading: true, error: null };
+    case FETCH_MISSIONS_SUCCESS:
+      return { ...state, data: action.payload, loading: false };
+    case FETCH_MISSIONS_FAILURE:
+      return { ...state, error: action.payload, loading: false };
+    default:
+      return state;
+  }
+};
+
+export default missionsReducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,0 +1,10 @@
+import { configureStore } from '@reduxjs/toolkit';
+import missionsReducer from './missions/reducers';
+
+const store = configureStore({
+  reducer: {
+    missions: missionsReducer,
+  },
+});
+
+export default store;


### PR DESCRIPTION
In this pull request, I have implemented the functionality to fetch data from the SpaceX API's Missions endpoint when a user navigates to the Missions section. The fetched data includes `mission_id`, `mission_name`, and `description`. I  ensured that the data is dispatched and stored in the Redux store only once, preventing redundant updates on every re-render when changing views or using navigation.

Changes Made:

- [x] Integrated a fetch request to the Missions endpoint (https://api.spacexdata.com/v3/missions) to obtain the required data.
- [x] Dispatched an action to store the fetched data (`mission_id`, `mission_name`, and `description`) in the Redux store.
- [x] Implemented a mechanism to ensure that data is dispatched and stored only once to avoid redundant updates on re-render during navigation.

Please review the changes and if there are any concerns or further improvements needed, kindly let me know. Thank you!

closes #18 