### PR TITLE
Implement mission joining - Actions 

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -4,7 +4,7 @@ import {
   Table,
   Spinner, Alert,
 } from 'react-bootstrap';
-import { fetchMissionsData } from '../redux/missions/missionsSlice';
+import { fetchMissionsData, joinMission } from '../redux/missions/missionsSlice';
 
 const MissionTable = () => {
   const dispatch = useDispatch();
@@ -29,6 +29,10 @@ const MissionTable = () => {
     );
   }
 
+  const handleJoinMission = (missionId) => {
+    dispatch(joinMission(missionId));
+  };
+
   return (
     <Table striped bordered hover>
       <thead>
@@ -46,7 +50,12 @@ const MissionTable = () => {
               <td>{mission.mission_name}</td>
               <td>{mission.description}</td>
               <td>Upcoming</td>
-              <td><button type="button">Join Mission</button></td>
+              <td>
+                <button type="button" onClick={() => handleJoinMission(mission.mission_id)}>
+                  Join Mission
+                </button>
+              </td>
+
             </tr>
           ))}
       </tbody>

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,23 +1,32 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Table } from 'react-bootstrap';
+import {
+  Table,
+  Spinner, Alert,
+} from 'react-bootstrap';
 import { fetchMissionsData } from '../redux/missions/missionsSlice';
 
 const MissionTable = () => {
+  const dispatch = useDispatch();
   const missionsData = useSelector((state) => state.missions.missionsData);
   const missionsStatus = useSelector((state) => state.missions.missionsStatus);
-  const dispatch = useDispatch();
+  const error = useSelector((state) => state.missions.error);
 
   useEffect(() => {
     dispatch(fetchMissionsData());
   }, [dispatch]);
 
   if (missionsStatus === 'loading') {
-    return <div>Loading...</div>;
+    return <Spinner animation="border" role="status" className="mt-4" />;
   }
 
   if (missionsStatus === 'failed') {
-    return <div>Error: Unable to fetch data for the missions</div>;
+    return (
+      <Alert variant="danger" className="mt-4">
+        Error:
+        {error}
+      </Alert>
+    );
   }
 
   return (

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -7,6 +7,7 @@ const initialState = {
   missionsError: null,
 };
 
+// Async Thunk: fetchMissionsData
 export const fetchMissionsData = createAsyncThunk('missions/fetchData', async () => {
   try {
     const response = await axios.get('https://api.spacexdata.com/v3/missions');
@@ -19,6 +20,15 @@ export const fetchMissionsData = createAsyncThunk('missions/fetchData', async ()
   } catch (error) {
     throw new Error('Unable to fetch data for the missions');
   }
+});
+
+// New action type
+const JOIN_MISSION = 'missions/joinMission';
+
+// New action creator function
+export const joinMission = (missionId) => ({
+  type: JOIN_MISSION,
+  payload: missionId,
 });
 
 const missionsSlice = createSlice({
@@ -37,6 +47,15 @@ const missionsSlice = createSlice({
       .addCase(fetchMissionsData.rejected, (state, action) => {
         state.missionsStatus = 'failed';
         state.missionsError = action.error.message;
+      })
+      // Handle the JOIN_MISSION action
+      .addCase(JOIN_MISSION, (state, action) => {
+        const selectedMissionId = action.payload;
+        // Create a new array of missions with the updated selected mission
+        state.missionsData = state.missionsData.map((mission) => (
+          mission.mission_id === selectedMissionId
+            ? { ...mission, reserved: true }
+            : mission));
       });
   },
 });

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -7,7 +7,6 @@ const initialState = {
   missionsError: null,
 };
 
-// Async Thunk: fetchMissionsData
 export const fetchMissionsData = createAsyncThunk('missions/fetchData', async () => {
   try {
     const response = await axios.get('https://api.spacexdata.com/v3/missions');
@@ -22,10 +21,8 @@ export const fetchMissionsData = createAsyncThunk('missions/fetchData', async ()
   }
 });
 
-// New action type
 const JOIN_MISSION = 'missions/joinMission';
 
-// New action creator function
 export const joinMission = (missionId) => ({
   type: JOIN_MISSION,
   payload: missionId,
@@ -48,10 +45,8 @@ const missionsSlice = createSlice({
         state.missionsStatus = 'failed';
         state.missionsError = action.error.message;
       })
-      // Handle the JOIN_MISSION action
       .addCase(JOIN_MISSION, (state, action) => {
         const selectedMissionId = action.payload;
-        // Create a new array of missions with the updated selected mission
         state.missionsData = state.missionsData.map((mission) => (
           mission.mission_id === selectedMissionId
             ? { ...mission, reserved: true }


### PR DESCRIPTION
In this pull request, I added the functionality to dispatch the "Join Mission" action when a user clicks on the button. The selected mission's ID is used to update the state in a non-mutating manner. A new state object is returned with all missions, and the selected mission has an additional key, `reserved`, set to `true`. To achieve this, the `map()` method is utilized to update the value of the new state.

## Changes Made:

- [x] Implemented the "Join Mission" action to update the store with the selected mission.
- [x] Extracted the ID of the selected mission when the user clicks the "Join Mission" button.
- [x] Updated the state in a non-mutating manner by returning a new state object with all missions, and the selected mission's `reserved` key set to `true`. 

Please review the changes and If there are any issues or further suggestions, kindly let me know. Thank you!