### PR TITLE
Implement mission leaving - Actions

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -45,8 +45,8 @@ const MissionTable = () => {
         </tr>
       </thead>
       <tbody>
-        {missionsData &&
-          missionsData.map((mission) => (
+        {missionsData
+          && missionsData.map((mission) => (
             <tr key={mission.mission_id}>
               <td>{mission.mission_name}</td>
               <td>{mission.description}</td>

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,10 +1,7 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import {
-  Table,
-  Spinner, Alert,
-} from 'react-bootstrap';
-import { fetchMissionsData, joinMission } from '../redux/missions/missionsSlice';
+import { Table, Spinner, Alert } from 'react-bootstrap';
+import { fetchMissionsData, joinMission, leaveMission } from '../redux/missions/missionsSlice';
 
 const MissionTable = () => {
   const dispatch = useDispatch();
@@ -33,6 +30,10 @@ const MissionTable = () => {
     dispatch(joinMission(missionId));
   };
 
+  const handleLeaveMission = (missionId) => {
+    dispatch(leaveMission(missionId));
+  };
+
   return (
     <Table striped bordered hover>
       <thead>
@@ -44,18 +45,23 @@ const MissionTable = () => {
         </tr>
       </thead>
       <tbody>
-        {missionsData
-          && missionsData.map((mission) => (
+        {missionsData &&
+          missionsData.map((mission) => (
             <tr key={mission.mission_id}>
               <td>{mission.mission_name}</td>
               <td>{mission.description}</td>
               <td>Upcoming</td>
               <td>
-                <button type="button" onClick={() => handleJoinMission(mission.mission_id)}>
-                  Join Mission
-                </button>
+                {mission.reserved ? (
+                  <button type="button" onClick={() => handleLeaveMission(mission.mission_id)}>
+                    Leave Mission
+                  </button>
+                ) : (
+                  <button type="button" onClick={() => handleJoinMission(mission.mission_id)}>
+                    Join Mission
+                  </button>
+                )}
               </td>
-
             </tr>
           ))}
       </tbody>

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -22,9 +22,15 @@ export const fetchMissionsData = createAsyncThunk('missions/fetchData', async ()
 });
 
 const JOIN_MISSION = 'missions/joinMission';
+const LEAVE_MISSION = 'missions/leaveMission';
 
 export const joinMission = (missionId) => ({
   type: JOIN_MISSION,
+  payload: missionId,
+});
+
+export const leaveMission = (missionId) => ({
+  type: LEAVE_MISSION,
   payload: missionId,
 });
 
@@ -50,6 +56,13 @@ const missionsSlice = createSlice({
         state.missionsData = state.missionsData.map((mission) => (
           mission.mission_id === selectedMissionId
             ? { ...mission, reserved: true }
+            : mission));
+      })
+      .addCase(LEAVE_MISSION, (state, action) => {
+        const selectedMissionId = action.payload;
+        state.missionsData = state.missionsData.map((mission) => (
+          mission.mission_id === selectedMissionId
+            ? { ...mission, reserved: false }
             : mission));
       });
   },


### PR DESCRIPTION
In this pull request, I followed the same logic as with the "Join Mission" action but introduced the functionality to dispatch the "Leave Mission" action when a user clicks the button. The selected mission's ID is used to update the state in a non-mutating manner. A new state object is returned with all missions, and the selected mission has the additional key, `reserved`, set to `false`. The `map()` method is utilized to update the value of the new state for the "Leave Mission" action.

## Changes Made:

- [x] Implemented the "Leave Mission" action to update the store with the selected mission.
- [x] Extracted the ID of the selected mission when the user clicks the "Leave Mission" button.
- [x] Updated the state in a non-mutating manner by returning a new state object with all missions, and the selected mission's `reserved` key set to `false`.

Please review the changes and if there are any issues or further suggestions, kindly let me know. 

Thank you!

closes #9 