### PR TITLE
Switch badges for Missions - Conditional components

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,6 +1,8 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Table, Spinner, Alert } from 'react-bootstrap';
+import {
+  Table, Spinner, Alert, Badge,
+} from 'react-bootstrap';
 import { fetchMissionsData, joinMission, leaveMission } from '../redux/missions/missionsSlice';
 
 const MissionTable = () => {
@@ -26,6 +28,9 @@ const MissionTable = () => {
     );
   }
 
+  const activeMemberBadge = 'Active Member';
+  const notAMemberBadge = 'NOT A MEMBER';
+
   const handleJoinMission = (missionId) => {
     dispatch(joinMission(missionId));
   };
@@ -50,7 +55,13 @@ const MissionTable = () => {
             <tr key={mission.mission_id}>
               <td>{mission.mission_name}</td>
               <td>{mission.description}</td>
-              <td>Upcoming</td>
+              <td>
+                {mission.reserved ? (
+                  <Badge variant="success">{activeMemberBadge}</Badge>
+                ) : (
+                  <Badge variant="danger">{notAMemberBadge}</Badge>
+                )}
+              </td>
               <td>
                 {mission.reserved ? (
                   <button type="button" onClick={() => handleLeaveMission(mission.mission_id)}>


### PR DESCRIPTION
In this pull request, I introduced conditional rendering for missions that the user has already joined. Instead of the default "NOT A MEMBER" badge and "Join Mission" button, the application now displays an "Active Member" badge and a "Leave Mission" button as per the design.

## Changes Made:

- [x] Implemented conditional rendering to check if the user has joined a mission.
- [x] When a user has joined a mission, the application now displays the "Active Member" badge and the "Leave Mission" button, replacing the default "NOT A MEMBER" badge and "Join Mission" button.

Please review the changes and if there are any issues or further suggestions, kindly let me know. Thank you!

closes #6
